### PR TITLE
Fix background handling in code blocks

### DIFF
--- a/index.css
+++ b/index.css
@@ -64,3 +64,8 @@ a {
 pre code {
   font-size: 14px;
 }
+
+pre > code {
+  display: block; 
+}
+}


### PR DESCRIPTION
While `code` and `kbd` set their background to some gray-ish color, the `<code>` element still gets rendered inline inside of `<pre>`. This leads to a rather ragged background inside the code block.

A quick fix is to change the element rule from `inline` to `block` for `<pre><code>`. This will result in a single uniform, rectangle shaped background.
